### PR TITLE
fix authentication bug in Issue #16

### DIFF
--- a/Assets/Scripts/Navigation/AuthenticationController.cs
+++ b/Assets/Scripts/Navigation/AuthenticationController.cs
@@ -70,6 +70,7 @@ public class AuthenticationController : MonoBehaviour
         try
         {
             MQ.Client qmClient = new MQ.Client(MQURLT, QMNameT, userNameT, apiKeyT);
+            qmClient.GetAllChannels();
 
             GameObject stateGameObject = GameObject.Find("State");
             State stateComponent = stateGameObject.GetComponent(typeof(State)) as State;
@@ -80,7 +81,7 @@ public class AuthenticationController : MonoBehaviour
         }
         catch
         {
-            Debug.Log("Error: Fail to connect to the Queue Manager");
+            Debug.Log("Error: Fail to connect to the Queue Manager. Please check your credentials, url, and queue manager's name.");
             errorNotification.SetActive(true);
             return;
         }


### PR DESCRIPTION
The REST API for login does not check whether the input queue manager's name is valid.
Therefore, on line 74 in AuthenticationController.cs, I've manually added an API call that would throw an exception if the queue manager's name is incorrect. This exception will cause the program to exit with an error message, which is what we want in this scenario.