### PR TITLE
Queue icon color corresponds to utilisation level

### DIFF
--- a/Assets/Scripts/Rendering/Queue.cs
+++ b/Assets/Scripts/Rendering/Queue.cs
@@ -191,16 +191,39 @@ public class Queue : MonoBehaviour
         }
 
         int messagePrefabNum = (int)Math.Ceiling(utilization * 20);
+        Material queueUtilisationColor = Resources.Load(messageColor) as Material;
+
         for (int i = 0; i < messagePrefabNum; i++)
         {
             Vector3 messagePosition = position;
             messagePosition.y = position.y + (i + 1) * 0.2f;
             GameObject instantiatedMessage = Instantiate(messagePrefab, messagePosition, Quaternion.identity) as GameObject;
             instantiatedMessage.transform.parent = this.transform;
-            instantiatedMessage.GetComponent<MeshRenderer>().material = Resources.Load(messageColor) as Material;
+            instantiatedMessage.GetComponent<MeshRenderer>().material = queueUtilisationColor;
 
             messages.Add(instantiatedMessage);
         }
+
+        // Change color of icon on top of queue to correspond to messages
+        // This relies on the fact the Queue prefab is first in hieararchy
+        // see GetComponentInChildren method
+        MeshRenderer queuePrefabMeshRenderer = gameObject.GetComponentInChildren<MeshRenderer>();
+        Material[] queueMaterials = queuePrefabMeshRenderer.materials;
+        Material[] newQueueMaterials = new Material[queueMaterials.Length];
+        for (int i = 0; i < queueMaterials.Length; i++)
+        {
+            Material material = queueMaterials[i];
+            // QueueBlue is the default utilisation color, so we know
+            // we have to change this material
+            if (material.name.Contains("QueueBlue"))
+            {
+                newQueueMaterials[i] = queueUtilisationColor;
+            } else
+            {
+                newQueueMaterials[i] = material;
+            }
+        }
+        queuePrefabMeshRenderer.materials = newQueueMaterials;
     }
 
     public void UpdateMessages(int newDepth)


### PR DESCRIPTION
- Change the queue icon color to correspond to utilisation level color
- TODO: Flashing lights for fully (red color) utilised queue

![Screenshot 2021-07-14 at 17 22 11](https://user-images.githubusercontent.com/13408109/125749445-e9203a77-6c8b-43f2-ba1c-493726665207.png)
