### PR TITLE
Make the QueueIcon flicker

### DIFF
--- a/Assets/Resources/Materials/QueueWhite2.mat
+++ b/Assets/Resources/Materials/QueueWhite2.mat
@@ -1,0 +1,78 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: QueueWhite
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0.44
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.73333335, g: 0.73333335, b: 0.73333335, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/Resources/Materials/QueueWhite2.mat.meta
+++ b/Assets/Resources/Materials/QueueWhite2.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e0c1ac0d85d8144ae8aa2a1ee7a9f1e9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Rendering/Queue.cs
+++ b/Assets/Scripts/Rendering/Queue.cs
@@ -182,10 +182,10 @@ public class Queue : MonoBehaviour
         {
             Material queueIconColor;
             // The color of queue icon would switch every 0.5 seconds
-            if (flickerTime % 1 > 0.5f)
+            if (flickerTime % 1 > 0.618f) // Golden ratio :)
             {
                 // Here the icon use BlockWhite material to distinguish with the QueueWhite material
-                queueIconColor = Resources.Load("Materials/BlockWhite") as Material;
+                queueIconColor = Resources.Load("Materials/QueueWhite2") as Material;
             }
             else
             {
@@ -196,7 +196,7 @@ public class Queue : MonoBehaviour
             {
                 Material material = queuePrefabMeshRenderer.materials[i];
                 // Here there are three possible materials for the Queue Icon, use them to find and change its material
-                if (material.name.Contains("QueueBlue") || material.name.Contains("QueueRed") || material.name.Contains("BlockWhite"))
+                if (material.name.Contains("QueueBlue") || material.name.Contains("QueueRed") || material.name.Contains("QueueWhite2"))
                 {
                     newQueueMaterials[i] = queueIconColor;
                 }

--- a/Assets/Scripts/Rendering/Queue.cs
+++ b/Assets/Scripts/Rendering/Queue.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 using MQ;
 
 
@@ -28,6 +29,12 @@ public class Queue : MonoBehaviour
 
     // Used for positioning
     public int rank;
+
+    // Use MeshRenderer to change and update the Queue object
+    private MeshRenderer queuePrefabMeshRenderer;
+
+    // Use for flickering the Queue Icon
+    private float flickerTime;
 
     void newQueueAdded(int rank)
     {
@@ -94,6 +101,8 @@ public class Queue : MonoBehaviour
         if (queue.holdsMessages)
         {
             int currentDepth = queue.currentDepth;
+            // Assign Queue MeshRenderer here for rendering the color of Queue Icon
+            queuePrefabMeshRenderer = gameObject.GetComponentInChildren<MeshRenderer>();
             CreateMessages(currentDepth, queue.maxNumberOfMessages);
 
         }
@@ -159,9 +168,47 @@ public class Queue : MonoBehaviour
         }
 
         textMesh.transform.rotation = Quaternion.LookRotation(usedQueue.textMesh.transform.position - Camera.main.transform.position);
-        
 
-       // textMesh.transform.rotation = Quaternion.LookRotation(textMesh.transform.position - Camera.main.transform.position);
+
+        // textMesh.transform.rotation = Quaternion.LookRotation(textMesh.transform.position - Camera.main.transform.position);
+
+
+        // The Queue Icon would flicker if the utilization is higher than 60%
+        int currentDepth = queue.currentDepth;
+        int MaximumDepth = queue.maxNumberOfMessages;
+        flickerTime += Time.deltaTime;
+        double utilization = (double)currentDepth / (double)MaximumDepth;
+        if (utilization > 0.6)
+        {
+            Material queueIconColor;
+            // The color of queue icon would switch every 0.5 seconds
+            if (flickerTime % 1 > 0.5f)
+            {
+                // Here the icon use BlockWhite material to distinguish with the QueueWhite material
+                queueIconColor = Resources.Load("Materials/BlockWhite") as Material;
+            }
+            else
+            {
+                queueIconColor = Resources.Load("Materials/QueueRed") as Material;
+            }
+            Material[] newQueueMaterials = new Material[queuePrefabMeshRenderer.materials.Length];
+            for (int i = 0; i < queuePrefabMeshRenderer.materials.Length; i++)
+            {
+                Material material = queuePrefabMeshRenderer.materials[i];
+                // Here there are three possible materials for the Queue Icon, use them to find and change its material
+                if (material.name.Contains("QueueBlue") || material.name.Contains("QueueRed") || material.name.Contains("BlockWhite"))
+                {
+                    newQueueMaterials[i] = queueIconColor;
+                }
+                else
+                {
+                    newQueueMaterials[i] = material;
+                }
+            }
+            // Upate the Queue with new materials
+            queuePrefabMeshRenderer.materials = newQueueMaterials;
+
+        }
 
 
     }
@@ -257,7 +304,6 @@ public class Queue : MonoBehaviour
         // Change color of icon on top of queue to correspond to messages
         // This relies on the fact the Queue prefab is first in hieararchy
         // see GetComponentInChildren method
-        MeshRenderer queuePrefabMeshRenderer = gameObject.GetComponentInChildren<MeshRenderer>();
         Material[] queueMaterials = queuePrefabMeshRenderer.materials;
         Material[] newQueueMaterials = new Material[queueMaterials.Length];
         for (int i = 0; i < queueMaterials.Length; i++)


### PR DESCRIPTION
The Icon would flicker red light when the utilization higher than 60% same with the color of messages. 
Use MeshRenderer to change the color of QueueIcon instead of using the Blender animation. I think this is an easier approach than the animation in script and it would not need more resource.